### PR TITLE
Simplify poetry install

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,6 +90,40 @@ In future sessions (on the CLI), you can enter the environment by navigating to 
 poetry shell
 ```
 
+#### Decoupling Python and Poetry installs
+
+When installing Poetry, it will usually bundle a Python install. But when using Homebrew, it tends to automatically
+update Poetry and the Python dependency. If it upgrades the minor Python version - like 3.10 -> 3.11 - it can break an
+existing environment.
+
+As such, it is best practice to decouple the Python install from Poetry. [`pyenv`](https://github.com/pyenv/pyenv) is a
+great, simple tool to manage Python installations.
+installs
+
+=== "Homebrew (on :material-apple:)"
+
+   ```shell
+   brew install pyenv
+   ```
+
+=== Other supported OS
+
+See <https://github.com/pyenv/pyenv#installation>.
+
+Then install a specific Python version. The executable path can be found with
+
+```shell
+pyenv which python
+```
+
+which can be used as the interpreter for the Poetry environment with
+
+```shell
+poetry env use "$(pyenv which python)"
+```
+
+Now you should have a static path to a specific Python install.
+
 ### Install the project
 
 === ":octicons-terminal-24: Command line"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,8 +116,7 @@ poetry shell
 
 ### Creating your own configuration
 
-To create your own Poetry configuration
-in [pyproject.toml](https://github.com/eshwen/ds-python-boilerplate/blob/main/pyproject.toml), run
+To create your own Poetry configuration in [pyproject.toml], run
 
 ```shell
 poetry init
@@ -130,8 +129,7 @@ cat requirements.txt | grep -E '^[^# ]' | cut -d= -f1 | xargs -n 1 poetry add
 cat requirements-dev.txt | grep -E '^[^# ]' | cut -d= -f1 | xargs -n 1 poetry add --group dev
 ```
 
-Dependencies can be segmented into different groups.
-See [pyproject.toml](https://github.com/eshwen/ds-python-boilerplate/blob/main/pyproject.toml).
+Dependencies can be segmented into different groups. See [pyproject.toml].
 
 It is recommended to maintain dependencies with Poetry, and export them to ``requirements.txt``
 and ``requirements-dev.txt`` if needed, e.g.,
@@ -179,3 +177,5 @@ poetry export --without-hashes --only dev -f requirements.txt -o requirements-de
     pip install -r requirements.txt
     pip install -r requirements-dev.txt
     ```
+
+[pyproject.toml]: https://github.com/eshwen/ds-python-boilerplate/blob/main/pyproject.toml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,13 +72,19 @@ First, install Poetry. This can be done through
     pip install poetry
     ```
 
-To ensure Poetry is up to date, run
+To ensure Poetry is up-to-date, run
 
 ```shell
 poetry self update
 ```
 
-Then create the `virtualenv` environment with
+Then, navigate to the project's root directory, and create the `virtualenv` environment with
+
+```shell
+poetry env use 3.10
+```
+
+In future sessions (on the CLI), you can enter the environment by navigating to the project's root directory and running
 
 ```shell
 poetry shell
@@ -100,14 +106,13 @@ poetry shell
     poetry install --without dev,test,docs
     ```
     
-    It will create a `virtualenv` environment for you, so you don't need to run it in conjunction with another environment manager, such as conda.
+    Since it will create a `virtualenv` environment for you, you don't need to run it in conjunction with another environment manager, such as conda.
 
 === ":simple-pycharm: PyCharm"
 
     1. Open the project
     2. Click **Add New Interpreter** -> **Add Local Interpreter...** -> **Poetry Environment**
-    3. Check **Poetry Environment**
-    4. For the **Base Interpreter**, the default option will probably do as Poetry will create a `virtualenv` environment to install everything inside
+    3. Check **Existing environment**. The environment you just created should appear in the dropdown menu
 
 ### Creating your own configuration
 
@@ -140,13 +145,13 @@ poetry export --without-hashes --only dev -f requirements.txt -o requirements-de
 
 1. For a lightweight experience, install `miniconda`. This can be done through
 
-    === "Homebrew (on :material-apple:)"
+   === "Homebrew (on :material-apple:)"
 
         ```shell
         brew install --cask miniconda
         ```
 
-    === "Other"
+   === "Other"
 
         Figure it out :material-emoticon-wink-outline:
 

--- a/docs/linting-formatting.md
+++ b/docs/linting-formatting.md
@@ -1,12 +1,15 @@
 # Linting and formatting
 
-Both linting and formatting are important for usable, readable code. They're often afterthoughts, but it's easy to configure and simply run tools to keep your code in tip-top shape.
+Both linting and formatting are important for usable, readable code. They're often afterthoughts, but it's easy to
+configure and simply run tools to keep your code in tip-top shape.
 
-All the tools are documented below, and configured under the corresponding sections in [pyproject.toml](https://github.com/eshwen/ds-python-boilerplate/blob/main/pyproject.toml).
+All the tools are documented below, and configured under the corresponding sections in [pyproject.toml].
 
 ## flake8
 
-[Flake8](<https://flake8.pycqa.org/en/latest/>) is widely-used linter with high configurability. Though it does not allow configuration with [pyproject.toml](https://github.com/eshwen/ds-python-boilerplate/blob/main/pyproject.toml), a third-party package [Flake8-pyproject](https://github.com/john-hen/Flake8-pyproject) makes this possible.
+[Flake8](<https://flake8.pycqa.org/en/latest/>) is widely-used linter with high configurability. Though it does not
+allow configuration with [pyproject.toml], a third-party
+package [Flake8-pyproject](https://github.com/john-hen/Flake8-pyproject) makes this possible.
 
 Run with
 
@@ -59,3 +62,5 @@ Run with
 ```shell
 pydocstyle --count my_project/
 ```
+
+[pyproject.toml]: https://github.com/eshwen/ds-python-boilerplate/blob/main/pyproject.toml


### PR DESCRIPTION
Todo:

- [x] Add comment about subtleties regarding `poetry env use`. The best practice is to decouple poetry and the Python install. So do

    ```shell
    brew install pyenv
    pyenv install 3.10.8
    poetry env use `<full path to Python executable>`
    ```