### PR TITLE
Don't globally exclude tests from pre-commit runs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 exclude: |
   (?x)^(
-    tests/.*\.py|
     mkdocs.yml
   )$
 


### PR DESCRIPTION
Don't globally exclude unit tests from pre-commit runs, otherwise the `name-tests-test` won't ever do anything

It's too tricky to get Mypy to ignore the test files, since any changed files are detected by pre-commit and forcibly piped to Mypy, meaning the `--exclude` arg won't have any effect

So I guess we just run `black`, `ruff`, and `mypy` over the unit tests as well as our normal code. It's probably a good idea, since we should maintain some level of quality for the unit tests