### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test Python Project
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/eshwen/ds-python-boilerplate/security/code-scanning/2](https://github.com/eshwen/ds-python-boilerplate/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best practice is to set this at the workflow level (top-level, after the `name` and before `on`), so it applies to all jobs unless overridden. For most test workflows, `contents: read` is sufficient unless a step requires additional permissions (e.g., uploading coverage reports, commenting on PRs). In this workflow, uploading to Codecov does not require write access to repository contents, so `contents: read` is appropriate. Add the following block after the `name` line:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
