### PR TITLE
Use default_install_hook_types to install hooks correctly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: |
 default_language_version:
   python: python3.10
 
-default_stages: [ pre-commit, pre-push ]
+default_install_hook_types: [ pre-commit, pre-push, post-checkout, post-merge, post-rewrite ]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Running `pre-commit install` without specifying the hook types will only install those that run at the `pre-commit` stage. It's annoying to ask the user to do `pre-commit install -t <hook> ...`, especially when the set of hooks is subject to change. So, specify and manage them in the config, then the user doesn't have to think about it